### PR TITLE
Connect browse matches to API

### DIFF
--- a/src/app/api/matches/route.ts
+++ b/src/app/api/matches/route.ts
@@ -1,0 +1,35 @@
+/* eslint-disable import/prefer-default-export */
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import authOptions from '@/lib/authOptions';
+import { prisma } from '@/lib/prisma';
+import { getMatchesByUserId } from '@/lib/dbActions';
+
+export async function GET() {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session || !session.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const userId = Number(session.user.id);
+
+    if (Number.isNaN(userId)) {
+      return NextResponse.json({ error: 'Invalid user id in session' }, { status: 400 });
+    }
+
+    const profile = await prisma.userProfile.findUnique({ where: { userId } });
+
+    if (!profile) {
+      return NextResponse.json({ error: 'User profile not found' }, { status: 404 });
+    }
+
+    const matches = await getMatchesByUserId(profile.id);
+
+    return NextResponse.json({ matches, currentProfileId: profile.id });
+  } catch (error) {
+    console.error('Error fetching matches:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/components/MatchCard.tsx
+++ b/src/components/MatchCard.tsx
@@ -13,7 +13,7 @@ import Link from 'next/link';
  * This should match the actual database schema for user profiles
  */
 interface MatchData {
-  id: number;
+  id: string;
   name: string;
   major: string;
   traits: string[]; // Array of traits like "Night Owl", "Tidy", "Introvert"


### PR DESCRIPTION
## Summary
- add an API endpoint to return matches for the signed-in user and expose their profile id
- update the Browse Matches page to fetch real matches, map profile data, and show loading/error states
- adjust MatchCard typing to align with database identifiers

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fb43af8c48327ada3abd597e61f1f)