### PR TITLE
Add match detail API data for comparison view

### DIFF
--- a/src/app/api/matches/[matchId]/route.ts
+++ b/src/app/api/matches/[matchId]/route.ts
@@ -1,6 +1,20 @@
 /* eslint-disable import/prefer-default-export */
 import { NextRequest, NextResponse } from 'next/server';
 import { getMatch } from '@/lib/dbActions';
+import buildComparisonData from '@/lib/comparison';
+import { CategoryBreakdown } from '@/types';
+
+function buildHighlights(categoryBreakdown: CategoryBreakdown[]) {
+  const compatibleTraits = categoryBreakdown
+    .filter((category) => category.compatibility >= 75)
+    .map((category) => `Aligned on ${category.category.toLowerCase()}: ${category.theirValue}`);
+
+  const conflicts = categoryBreakdown
+    .filter((category) => category.compatibility < 60)
+    .map((category) => `Different ${category.category.toLowerCase()}: ${category.yourValue} vs ${category.theirValue}`);
+
+  return { compatibleTraits, conflicts };
+}
 
 export async function GET(
   req: NextRequest,
@@ -8,6 +22,15 @@ export async function GET(
 ) {
   try {
     const { matchId } = params;
+    const { searchParams } = new URL(req.url);
+    const currentUserId = searchParams.get('userId');
+
+    if (!currentUserId) {
+      return NextResponse.json(
+        { error: 'User ID required' },
+        { status: 400 },
+      );
+    }
 
     // Get match with both user profiles
     const match = await getMatch(matchId);
@@ -19,10 +42,31 @@ export async function GET(
       );
     }
 
+    if (match.user1Id !== currentUserId && match.user2Id !== currentUserId) {
+      return NextResponse.json(
+        { error: 'User is not part of this match' },
+        { status: 403 },
+      );
+    }
+
+    const isUser1 = match.user1Id === currentUserId;
+    const currentUser = isUser1 ? match.user1 : match.user2;
+    const matchUser = isUser1 ? match.user2 : match.user1;
+
+    if (!currentUser || !matchUser) {
+      return NextResponse.json(
+        { error: 'Missing user profiles for match' },
+        { status: 500 },
+      );
+    }
+
+    const comparisonData = buildComparisonData(currentUser, matchUser, match);
+    const { compatibleTraits, conflicts } = buildHighlights(comparisonData.categoryBreakdown);
+
     return NextResponse.json({
-      match,
-      user1: match.user1,
-      user2: match.user2,
+      ...comparisonData,
+      compatibleTraits,
+      conflicts,
     });
   } catch (error) {
     console.error('Error fetching match:', error);

--- a/src/app/comparison/[matchId]/page.tsx
+++ b/src/app/comparison/[matchId]/page.tsx
@@ -6,8 +6,15 @@
 
 import { useEffect, useState } from 'react';
 import { useParams, useSearchParams } from 'next/navigation';
-import { Container, Row, Col, Card, Button } from 'react-bootstrap';
-import { ComparisonData } from '@/types';
+import {
+  Card,
+  Col,
+  Container,
+  Row,
+  Button,
+  ListGroup,
+} from 'react-bootstrap';
+import { MatchDetailData } from '@/types';
 import SideBySideComparison from '@/components/SideBySideComparison';
 import CompatibilityReportBox from '@/components/CompatibilityReport';
 import IcebreakersBox from '@/components/Icebreakers';
@@ -18,7 +25,7 @@ export default function ComparisonPage() {
   const matchId = params.matchId as string;
   const userId = searchParams.get('userId');
 
-  const [data, setData] = useState<ComparisonData | null>(null);
+  const [data, setData] = useState<MatchDetailData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -31,11 +38,11 @@ export default function ComparisonPage() {
       }
 
       try {
-        const res = await fetch(`/api/matches/${matchId}/comparison?userId=${userId}`);
+        const res = await fetch(`/api/matches/${matchId}?userId=${userId}`);
         if (!res.ok) throw new Error('Failed to fetch comparison data');
 
         const comparisonData = await res.json();
-        setData(comparisonData);
+        setData(comparisonData as MatchDetailData);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'An error occurred');
       } finally {
@@ -117,6 +124,69 @@ export default function ComparisonPage() {
               categoryBreakdown={data.categoryBreakdown}
               overallScore={data.match.overallScore}
             />
+          </Col>
+        </Row>
+
+        <Row className="mb-4 g-4">
+          <Col lg={6}>
+            <Card className="shadow-sm h-100">
+              <Card.Body className="p-4">
+                <div className="d-flex align-items-center gap-2 mb-3">
+                  <div
+                    className="bg-success bg-opacity-10 text-success d-flex align-items-center justify-content-center rounded"
+                    style={{ width: '44px', height: '44px' }}
+                  >
+                    <i className="bi bi-hand-thumbs-up" />
+                  </div>
+                  <div>
+                    <h5 className="fw-bold mb-0">Compatible Traits</h5>
+                    <small className="text-muted">Where your lifestyles naturally align</small>
+                  </div>
+                </div>
+                {data.compatibleTraits.length > 0 ? (
+                  <ListGroup variant="flush">
+                    {data.compatibleTraits.map((trait, index) => (
+                      <ListGroup.Item key={trait + index} className="px-0">
+                        <i className="bi bi-check-circle text-success me-2" />
+                        {trait}
+                      </ListGroup.Item>
+                    ))}
+                  </ListGroup>
+                ) : (
+                  <p className="text-muted mb-0">No strong alignments identified yet.</p>
+                )}
+              </Card.Body>
+            </Card>
+          </Col>
+          <Col lg={6}>
+            <Card className="shadow-sm h-100">
+              <Card.Body className="p-4">
+                <div className="d-flex align-items-center gap-2 mb-3">
+                  <div
+                    className="bg-danger bg-opacity-10 text-danger d-flex align-items-center justify-content-center rounded"
+                    style={{ width: '44px', height: '44px' }}
+                  >
+                    <i className="bi bi-exclamation-triangle" />
+                  </div>
+                  <div>
+                    <h5 className="fw-bold mb-0">Potential Conflicts</h5>
+                    <small className="text-muted">Areas to discuss early</small>
+                  </div>
+                </div>
+                {data.conflicts.length > 0 ? (
+                  <ListGroup variant="flush">
+                    {data.conflicts.map((conflict, index) => (
+                      <ListGroup.Item key={conflict + index} className="px-0">
+                        <i className="bi bi-dot text-danger me-2" />
+                        {conflict}
+                      </ListGroup.Item>
+                    ))}
+                  </ListGroup>
+                ) : (
+                  <p className="text-muted mb-0">No major conflicts detected.</p>
+                )}
+              </Card.Body>
+            </Card>
           </Col>
         </Row>
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,6 +20,11 @@ export interface ComparisonData {
   categoryBreakdown: CategoryBreakdown[];
 }
 
+export interface MatchDetailData extends ComparisonData {
+  compatibleTraits: string[];
+  conflicts: string[];
+}
+
 export interface CategoryBreakdown {
   category: string;
   yourValue: string | number;


### PR DESCRIPTION
## Summary
- add a match detail API response that orients data to the requesting user and includes compatibility highlights
- extend shared types for the detailed match payload
- update the comparison page to consume the new endpoint and render compatible traits and potential conflicts

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fbb0f453883279ec1831336a4ae55)